### PR TITLE
Rename GVM to SDKMAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ TDDBC for Java with JUnit
 # Mac
 $ brew install gradle
 または、
-$ gvm install gradle
+$ sdk install gradle
 
 # Unix
-$ gvm install gradle
+$ sdk install gradle
 ```
-gvmについては、以下のURLを参考にしてインストールしてください
+sdkについては、以下のURLを参考にしてインストールしてください
 
-http://gvmtool.net/
+http://sdkman.io/
 
 #### Windows
 以下のURLを参考にしてインストールしてください。


### PR DESCRIPTION
名前変わってリンク先も変わってます。
そのままでもリダイレクトされるけれど、初見で違うところに飛ばされると戸惑うと思いますので。