### PR TITLE
Update Java8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ out/
 # Eclipse
 .classpath
 .project
+.settings/

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ project.ext {
 }
 version = '1.0-SNAPSHOT'
 
-sourceCompatibility = targetCompatibility = 1.7
+sourceCompatibility = targetCompatibility = 1.8
 
 tasks.withType(AbstractCompile) each { it.options.encoding = 'UTF-8' }
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-eclipse-plugin</artifactId>
+        <version>2.10</version>
         <configuration>
           <downloadSources>true</downloadSources>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,14 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-eclipse-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
もうJava8でいいですよね。

この流れで、gradleでバージョン指定していてmavenで指定してないのが気になったので、mavenでも指定するようにしました。
mavenプラグインのバージョン指定してないとmavenがWARNログが出る（指定しない場合は使用しているMavenのバージョンのデフォルトのプラグインが使用される）ので、指定しておく。
mavenプラグインの設定を変えたので`mvn eclipse:eclipse`したら`.settings/`が差分で出てきたのでignoreに追加しました。