### PR TITLE
Update junit version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.11', { exclude module: 'hamcrest-core' }
+    testCompile 'junit:junit:4.12', { exclude module: 'hamcrest-core' }
     testCompile 'org.hamcrest:hamcrest-all:1.3'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12', { exclude module: 'hamcrest-core' }
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }
 
 wrapper {

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
+      <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
JUnit4.12にしておきます。

gradleとmavenで使用されるライブラリが微妙に違っていたので、あわせておきます。
（hamcrest-coreがmavenの方では入る。）
hamcrest-allを使いたい動機はhamcrest-libraryだと思われるので、
hamcrest-coreをexcludeせずhamcrest-libraryを足す方向にしてみました。